### PR TITLE
Fix server-side rendering by reading document only when defined

### DIFF
--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -42,7 +42,7 @@ class TetherComponent extends Component {
 
   static defaultProps = {
     renderElementTag: 'div',
-    renderElementTo: document.body
+    renderElementTo: typeof document !== 'undefined' && document.body
   }
 
   _targetNode = null


### PR DESCRIPTION
Fixes #4

This fix makes the reference to `document.body` evaluate only if `document` is defined.