### PR TITLE
Only unmount if it has already been mounted

### DIFF
--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -75,15 +75,17 @@ class TetherComponent extends Component {
   }
 
   _destroy() {
-    ReactDOM.unmountComponentAtNode(this._elementParentNode)
-    this._elementParentNode.parentNode.removeChild(this._elementParentNode)
-
-    if (this._tether) {
-      this._tether.destroy()
+    if (this._elementParentNode) {
+      ReactDOM.unmountComponentAtNode(this._elementParentNode)
+      this._elementParentNode.parentNode.removeChild(this._elementParentNode)
+  
+      if (this._tether) {
+        this._tether.destroy()
+      }
+  
+      this._elementParentNode = null
+      this._tether = null
     }
-
-    this._elementParentNode = null
-    this._tether = null
   }
 
   _update() {


### PR DESCRIPTION
See https://github.com/souporserious/react-tether/issues/8

It seems that this `destroy` method can get called before `this._elementParentNode` is ever initialized, which throws an error when React tries to unmount `null`.