### PR TITLE
Make dependencies to be peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/souporserious/react-tether/issues"
   },
   "homepage": "https://github.com/souporserious/react-tether",
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "tether": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
     "url": "https://github.com/souporserious/react-tether/issues"
   },
   "homepage": "https://github.com/souporserious/react-tether",
+  "dependencies": {
+    "tether": "^1.1.1"
+  },
   "peerDependencies": {
     "react": "^0.14.0",
-    "react-dom": "^0.14.0",
-    "tether": "^1.1.1"
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^2.0.0",


### PR DESCRIPTION
There is an issue if you use old version of npm and use webpack as builder. In this case we have two different versions of react in one bundle file.