### PR TITLE
Render fixes

### DIFF
--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -103,7 +103,7 @@ class TetherComponent extends Component {
   }
 
   _update() {
-    const { children, renderElementTag, renderElementTo } = this.props
+    const { children, renderElementTag } = this.props
     let elementComponent = children[1]
 
     // if no element component provided, bail out

--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -58,17 +58,10 @@ class TetherComponent extends Component {
 
   componentDidMount() {
     this._targetNode = ReactDOM.findDOMNode(this)
-    this._renderNode = document.querySelector(this.props.renderElementTo) || document.body
     this._update()
   }
 
   componentDidUpdate(prevProps) {
-    const { renderElementTo } = this.props
-
-    if (prevProps.renderElementTo !== renderElementTo) {
-      this._renderNode = document.querySelector(renderElementTo) || document.body
-    }
-
     this._update()
   }
 
@@ -131,6 +124,11 @@ class TetherComponent extends Component {
         this._updateTether()
       }
     )
+  }
+
+  get _renderNode() {
+    const { renderElementTo } = this.props
+    return document.querySelector(renderElementTo) || document.body
   }
 
   _updateTether() {

--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -15,6 +15,13 @@ const childrenPropType = ({ children }, propName, componentName) => {
   }
 }
 
+const renderElementToTypes = [
+  PropTypes.string,
+  PropTypes.shape({
+    appendChild: PropTypes.func.isRequired
+  })
+]
+
 const attachmentPositions = [
   'top left',
   'top center',
@@ -30,7 +37,7 @@ const attachmentPositions = [
 class TetherComponent extends Component {
   static propTypes = {
     renderElementTag: PropTypes.string,
-    renderElementTo: PropTypes.string,
+    renderElementTo: PropTypes.oneOfType(renderElementToTypes),
     attachment: PropTypes.oneOf(attachmentPositions).isRequired,
     targetAttachment: PropTypes.oneOf(attachmentPositions),
     offset: PropTypes.string,
@@ -128,7 +135,11 @@ class TetherComponent extends Component {
 
   get _renderNode() {
     const { renderElementTo } = this.props
-    return document.querySelector(renderElementTo) || document.body
+    if (typeof renderElementTo === 'string') {
+      return document.querySelector(renderElementTo)
+    } else {
+      return renderElementTo || document.body
+    }
   }
 
   _updateTether() {


### PR DESCRIPTION
This PR fixes a couple issues I ran into:

* I was still having difficulty setting the `renderElementTo` node after #16 was closed.  I think the root of the problem is that since the render node is computed as soon as the `TetherComponent` is mounted, it doesn't "give me a chance" to find the node I want to render into.  If we instead lazily evaluate the node retrieval (i.e. only in `update`) we can specify nodes that might not exist yet.
* Commit https://github.com/souporserious/react-tether/commit/78859ddcf633cdaef35eeebbe7e939ff9f164083 restricted `renderElementTo` to a string (i.e. a query selector) but sometimes it may not be possible to give a selector; for instance if the target is a React component, all that is available is the DOM element (adding IDs/classes for this seems very anti-React).  This adds the ability to specify either a query selector or a DOM node.