### PR TITLE
Export valid attachment position

### DIFF
--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -22,7 +22,7 @@ const childrenPropType = ({ children }, propName, componentName) => {
   }
 }
 
-const attachmentPositions = [
+export const attachmentPositions = [
   'top left',
   'top center',
   'top right',


### PR DESCRIPTION
I'd like these to be exported so that lib clients can validate position on their side without duplicating this list.
In my case I built a wrapper for a tooltip component and I'd like my wrapper to also declare proptypes. 
Also need ability to validate positions at app startup time (ie I create HOC using positions) instead or runtime

Maybe my usecase is not that clear but I'm sure it's not a big deal to export these positions anyway