### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,19 @@
+# Mac OSX Files
+.DS_Store
+.Trashes
+.Spotlight-V100
+.AppleDouble
+.LSOverride
+
+# APP
+node_modules
+npm-debug.log
+
+# General Files
+.sass-cache
+.hg
+.idea
+.svn
+.cache
+.project
+.tmp


### PR DESCRIPTION
This will include the transpiled scripts when publishing to NPM. Currently the 0.5.4 release is broken due to missing transpiled scripts since the folder `lib` is ignore due to NPM falling back to `.gitignore` if `.npmignore` is not found.