### PR TITLE
Compatibility React 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "node-libs-browser": "^1.0.0",
     "node-sass": "^3.2.0",
     "postcss-loader": "^0.13.0",
+    "prop-types": "^15.5.8",
     "react": "15.3.2",
     "react-dom": "15.3.2",
     "react-motion": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/souporserious/react-tether",
   "dependencies": {
+    "prop-types": "^15.5.8",
     "tether": "^1.3.7"
   },
   "peerDependencies": {
@@ -51,7 +52,6 @@
     "node-libs-browser": "^1.0.0",
     "node-sass": "^3.2.0",
     "postcss-loader": "^0.13.0",
-    "prop-types": "^15.5.8",
     "react": "15.3.2",
     "react-dom": "15.3.2",
     "react-motion": "^0.4.2",

--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -1,4 +1,5 @@
-import React, { Component, Children, PropTypes } from 'react'
+import React, { Component, Children } from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import Tether from 'tether'
 


### PR DESCRIPTION
Small PR to remove the deprecated React.PropTypes for React 15.5.
