### PR TITLE
Replace findDOMNode with ref.

### DIFF
--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Children } from 'react'
+import React, { Component, Children, cloneElement } from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import Tether from 'tether'
@@ -68,12 +68,10 @@ class TetherComponent extends Component {
   _tether = false
 
   componentDidMount() {
-    this._targetNode = ReactDOM.findDOMNode(this)
     this._update()
   }
 
   componentDidUpdate(prevProps) {
-    this._targetNode = ReactDOM.findDOMNode(this)
     this._update()
   }
 
@@ -208,7 +206,9 @@ class TetherComponent extends Component {
   }
 
   render() {
-    return Children.toArray(this.props.children)[0]
+    return cloneElement(Children.toArray(this.props.children)[0], {
+      ref: el => this._targetNode = el
+    })
   }
 }
 


### PR DESCRIPTION
## Reason

Cannot use Jest Snapshot testing with `react-tether` because of it using `React.findDOMNode` API. `react-test-renderer` does not support `findDOMNode` but does support `refs`. See https://github.com/facebook/react/issues/7371.

<img width="753" alt="screen shot 2017-08-14 at 13 04 26" src="https://user-images.githubusercontent.com/474603/29270984-2949de76-80f1-11e7-8d5d-0ba76d808111.png">

## What's included

Just replace `findDOMNode` with an explicit ref to the targetNode.

All good to use with Jest snapshots now! 🎉 

